### PR TITLE
Updated Jackson version to 2.9.5 because vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <!-- while merging com.amazonaws.services.s3.transfer.MultipleFileUpload , I couldn't compile without setting a version here -->
         <aws-java-sdk.version>1.11.15</aws-java-sdk.version>
-        <jackson.version>2.9.1</jackson.version>
+        <jackson.version>2.9.5</jackson.version>
         <spring.version>5.0.0.RELEASE</spring.version>
         <hibernate.version>5.2.11.Final</hibernate.version>
         <jpa.version>2.2</jpa.version>


### PR DESCRIPTION
The Github repository is complaining about vulnerabilities in Jackson databind so I updated the version to 2.9.5. 

https://nvd.nist.gov/vuln/detail/CVE-2018-7489
https://nvd.nist.gov/vuln/detail/CVE-2017-17485